### PR TITLE
docs: improve readme understandability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Blueprint implements the following steps:
 ## Requirements
 
 - Install argo CLI: https://argo-cd.readthedocs.io/en/stable/cli_installation/
-- Have Krateo PlatformOps 2.6.0 installed: https://docs.krateo.io/
+- Have Krateo PlatformOps >= 2.6.0 installed: https://docs.krateo.io/
 
 ### Setup toolchain on krateo-system namespace
 
@@ -112,11 +112,21 @@ spec:
 EOF
 ```
 
-## Usage
+## Installation
 
-### Install the Helm Chart
+There are three ways to install this Blueprint:
 
-Download Helm Chart values:
+- [1. Helm Chart](#method-1-helm-chart) 
+- [2. Krateo Composable Operation](#method-2-krateo-composable-operation)
+- [3. Krateo Composable Portal](#method-3-krateo-composable-portal)
+
+---
+
+### Method 1: Helm Chart
+
+> Note: In this installation method some advanced features, like the edit of the values of the chart, are disabled.
+
+**Step 1: Download the default Helm chart values**
 
 ```sh
 helm repo add marketplace https://marketplace.krateo.io
@@ -124,9 +134,20 @@ helm repo update marketplace
 helm inspect values marketplace/github-scaffolding-with-composition-page --version 1.2.5 > ~/github-scaffolding-with-composition-page-values.yaml
 ```
 
-Modify the *github-scaffolding-with-composition-page-values.yaml* file as the following example:
+**Step 2: Edit the values file**
+
+Modify `~/github-scaffolding-with-composition-page-values.yaml` as shown below:
 
 ```yaml
+global:
+  compositionName: <release-name>
+  compositionNamespace: <release-namespace>
+  compositionInstalledVersion: v1-2-5
+  compositionApiVersion: composition.krateo.io/v1-2-5
+  compositionGroup: composition.krateo.io
+  compositionResource: githubscaffoldingwithcompositionpages
+  compositionKind: GithubScaffoldingWithCompositionPage
+  krateoNamespace: krateo-system
 argocd:
   namespace: krateo-system
   application:
@@ -181,7 +202,7 @@ git:
       namespace: demo-system
 ```
 
-Install the Blueprint:
+**Step 3: Install the blueprint**
 
 ```sh
 helm install <release-name> github-scaffolding-with-composition-page \
@@ -193,9 +214,11 @@ helm install <release-name> github-scaffolding-with-composition-page \
   --wait
 ```
 
-### Install using Krateo Composable Operation
+---
 
-Install the CompositionDefinition for the *Blueprint*:
+### Method 2: Krateo Composable Operation
+
+**Step 1: Install the `CompositionDefinition`**
 
 ```sh
 cat <<EOF | kubectl apply -f -
@@ -212,11 +235,16 @@ spec:
 EOF
 ```
 
-Install the Blueprint using, as metadata.name, the *Composition* name (the Helm Chart name of the composition):
+As a result of this command:
+- The core-provider generates a new Custom Resource Definition (CRD) based on the `github-scaffolding-with-composition-page` chart's schema.
+- Resources of kind `GithubScaffoldingWithCompositionPage` (with `apiVersion: composition.krateo.io/v1-2-5`) can be created in the cluster.
+
+
+**Step 2: Install the Blueprint**
 
 ```sh
 cat <<EOF | kubectl apply -f -
-apiVersion: composition.krateo.io/v1-2-2
+apiVersion: composition.krateo.io/v1-2-5
 kind: GithubScaffoldingWithCompositionPage
 metadata:
   name: <release-name> 
@@ -277,11 +305,19 @@ spec:
 EOF
 ```
 
-### Install using Krateo Composable Portal
+This command:
+- Creates a Composition resource, which deploys the `github-scaffolding-with-composition-page` chart (version 1.2.5).
+- Uses the configurations provided in the spec block to override the chart's default values.
+
+---
+
+### Method 3: Krateo Composable Portal
+
+**Step 1: Apply the `portal-blueprint-page` `CompositionDefinition`**
 
 ```sh
 cat <<EOF | kubectl apply -f -
-apiVersion: core.krateo.io/v1alpha1
+apiVersion: core.krateo.io/v1alpha1 
 kind: CompositionDefinition
 metadata:
   name: portal-blueprint-page
@@ -294,7 +330,14 @@ spec:
 EOF
 ```
 
-Install the Blueprint using, as metadata.name, the *Blueprint* name (the Helm Chart name of the blueprint):
+As a result of this command:
+- The core-provider generates a new Custom Resource Definition (CRD) based on the `portal-blueprint-page` chart's schema.
+- Resources of kind `PortalBlueprintPage` (with `apiVersion: composition.krateo.io/v1-0-6`) can now be created in the cluster.
+
+
+**Step 2: Install the Blueprint**
+
+> Note: `metadata.name` and `spec.blueprint.repo` must be the same.
 
 ```sh
 cat <<EOF | kubectl apply -f -
@@ -317,3 +360,31 @@ spec:
       name: fa-cubes
 EOF
 ```
+
+As a result of this command:
+- A new `PortalBlueprintPage` Composition is created, which deploys the portal widgets and generates a new `CompositionDefinition` for the `github-scaffolding-with-composition-page` chart using the values provided in `spec.blueprint`.
+- A blueprint card is created in the Krateo Portal's "Blueprints" section, allowing users to configure and deploy this blueprint directly from the UI.
+
+
+---
+
+## Access the FireworksApp (Optional)
+
+This blueprint scaffolds the Fireworks app, which is a basic web page. To access it, edit the field `spec.argocd.application.syncEnabled` to `true`, either in the _"Values"_ section of the compostion from the portal, or with the following command:
+
+```sh
+kubectl patch githubscaffoldingwithcompositionpage my-fireworks-app \
+  -n krateo-system \
+  --type='merge' \
+  -p '{"spec":{"argocd":{"application":{"syncEnabled":true}}}}'
+```
+
+Once patched, the ArgoCD application begins reconciling the state of the repository with the cluster, creating the Deployment and Service for the Fireworks app.
+
+Port-forward the service to your local machine:
+
+```sh
+kubectl port-forward -n krateo-system svc/my-fireworks-app 31180:31180
+```
+
+From the browser, open the FireworksApp at `http://localhost:31180`.


### PR DESCRIPTION
Added global values to the first installation method (plain helm chart).

The underlying `portal-compostion-page-generic` recently started using global values in its templates, hence this addition.

In spite of all that, some features (as indicated in the README), still remain disabled, such as the editing of the composition's values.

This is because the restaction looks for the kind `GitHubScaffoldingWithCompostionPage`, which does not get created for this method.

Added a guide on how to actually open the FireworksApp at the end for completeness.